### PR TITLE
Surgical and pathology reports text conversion

### DIFF
--- a/notebooks/reading_pdf.ipynb
+++ b/notebooks/reading_pdf.ipynb
@@ -1,0 +1,446 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reading PDF Documents as Text Files\n",
+    "This notebook explores different packages that could be used to read the pdf files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pdfminer.high_level import extract_text\n",
+    "import pytesseract\n",
+    "import PyPDF2\n",
+    "from pdf2image import convert_from_path\n",
+    "\n",
+    "\n",
+    "cwd = os.getcwd()\n",
+    "pathology_file_example_path = os.path.join(cwd, \"..\", \"data\", \"raw_data\", \"pdf\", \"pathology\", \"51 P.pdf\")\n",
+    "surgical_file_example_path = os.path.join(cwd, \"..\", \"data\", \"raw_data\", \"pdf\", \"surgical\", \"51 O.pdf\")\n",
+    "ultrasound_file_example_path = os.path.join(cwd, \"..\", \"data\", \"raw_data\", \"pdf\", \"ultrasound\", \"51 U.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ultrasound Reports\n",
+    "This seems straightforward enough we can use `pdfminer`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Centre Universitaire de Santé McGill\n",
+      "Imagerie Médicale\n",
+      "\n",
+      "McGill University Health Centre\n",
+      "Medical Imaging\n",
+      "\n",
+      "m/Name:\n",
+      "Accession #:\n",
+      "\n",
+      "Med Ref/Req MD:\n",
+      "Autre Med/Other MD:\n",
+      "\n",
+      "Stewart, Jessica,\n",
+      "\n",
+      "Dossier/MRN:\n",
+      "Location/Service:\n",
+      "\n",
+      "Sexe/Sex:\n",
+      "DDN/DOB:\n",
+      "RAMQ:\n",
+      "Org:\n",
+      "Rapport/Report:\n",
+      "\n",
+      "Examen / Exam\n",
+      "\n",
+      " \n",
+      "\n",
+      "US US ABDOMEN/PELVIS- APPENDICITIS -AB\n",
+      "\n",
+      "Date d'examen / Exam Date\n",
+      "March 12, 2014 16:14\n",
+      "\n",
+      "RENSEIGNEMENT CLINIQUE / CLINICAL INFORMATION:\n",
+      "\n",
+      "Right lower quadrant pain.  Query appendicitis.\n",
+      "\n",
+      "PROTOCOLE RADIOLOGIQUE / RADIOLOGIST'S REPORT:\n",
+      "\n",
+      "ULTRASOUND ABDOMEN AND PELVIS\n",
+      "\n",
+      "The liver has slightly increased periportal echoes.  Gallbladder and biliary tree within normal\n",
+      "limits.  Visualized part of the pancreas within normal limits.\n",
+      "\n",
+      "The spleen has a normal appearance and measures 12.5cm.\n",
+      "\n",
+      "The right kidney measures 12.5cm and the left kidney also measures 12.5cm.  No evidence of\n",
+      "hydronephrosis.  The parenchyma of both kidneys is unremarkable.\n",
+      "\n",
+      "The bladder is partially filled.\n",
+      "\n",
+      "In the right lower quadrant there is a blind ending loop measuring 12mm in transverse diameter.\n",
+      "  The adjacent mesentery appears of increased echotexture suggestive of mesenteric stranding\n",
+      "and edema.  The patient is very tender in that area and the structure is non-compressible.  No\n",
+      "obvious fluid collection seen.\n",
+      "\n",
+      "The appearance is compatible with acute appendicitis.  No obvious fluid collection seen.\n",
+      "\n",
+      " \n",
+      " \n",
+      "Electronically signed by: Ricardo Faingold MD (Mar 29, 2014 10:41:47)\n",
+      "\n",
+      "Radiologiste/Reporting MD:\n",
+      "Date Dictée/Dictated:\n",
+      "Transcription par/by:\n",
+      "Date de transcription/Date Typed:\n",
+      "\n",
+      "Faingold MD, Ricardo\n",
+      "March 12, 2014 16:58\n",
+      "R. C\n",
+      "March 26, 2014 13:53\n",
+      "\n",
+      "Hôpital de Montréal pour Enfants / Montreal Children's Hospital\n",
+      "1001 boul. Décarie, Montréal, Québec, H4A 3J1\n",
+      "Page 1 of 1\n",
+      "\n",
+      "\f\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(extract_text(ultrasound_file_example_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Surgical Reports\n",
+    "Here `pdfminer` doesn't work as well :\"("
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User: 0870530 \n",
+      "\n",
+      " 1 \n",
+      "\n",
+      " 2021-12-06 13:39:05\n",
+      "\n",
+      "\fUser: 0870530 \n",
+      "\n",
+      " 2 \n",
+      "\n",
+      " 2021-12-06 13:39:05\n",
+      "\n",
+      "\f\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Using pdfminer\n",
+    "print(extract_text(surgical_file_example_path))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try with `pytesseract`. Difficult to install."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TesseractError",
+     "evalue": "(1, 'Tesseract Open Source OCR Engine v4.1.1 with Leptonica Error in pixReadStream: Pdf reading is not supported Error in pixRead: pix not read Error during processing.')",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTesseractError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m/home/c_spino/research/NLP_ultrasound_report/notebooks/reading_pdf.ipynb Cell 8'\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell://wsl%2Bubuntu/home/c_spino/research/NLP_ultrasound_report/notebooks/reading_pdf.ipynb#ch0000008vscode-remote?line=0'>1</a>\u001b[0m \u001b[39m# Get a searchable PDF\u001b[39;00m\n\u001b[0;32m----> <a href='vscode-notebook-cell://wsl%2Bubuntu/home/c_spino/research/NLP_ultrasound_report/notebooks/reading_pdf.ipynb#ch0000008vscode-remote?line=1'>2</a>\u001b[0m pdf \u001b[39m=\u001b[39m pytesseract\u001b[39m.\u001b[39;49mimage_to_pdf_or_hocr(surgical_file_example_path, extension\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mpdf\u001b[39;49m\u001b[39m'\u001b[39;49m)\n\u001b[1;32m      <a href='vscode-notebook-cell://wsl%2Bubuntu/home/c_spino/research/NLP_ultrasound_report/notebooks/reading_pdf.ipynb#ch0000008vscode-remote?line=2'>3</a>\u001b[0m \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39m(\u001b[39m'\u001b[39m\u001b[39mtest.pdf\u001b[39m\u001b[39m'\u001b[39m, \u001b[39m'\u001b[39m\u001b[39mw+b\u001b[39m\u001b[39m'\u001b[39m) \u001b[39mas\u001b[39;00m f:\n\u001b[1;32m      <a href='vscode-notebook-cell://wsl%2Bubuntu/home/c_spino/research/NLP_ultrasound_report/notebooks/reading_pdf.ipynb#ch0000008vscode-remote?line=3'>4</a>\u001b[0m     f\u001b[39m.\u001b[39mwrite(pdf)\n",
+      "File \u001b[0;32m~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py:439\u001b[0m, in \u001b[0;36mimage_to_pdf_or_hocr\u001b[0;34m(image, lang, config, nice, extension, timeout)\u001b[0m\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=435'>436</a>\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mUnsupported extension: \u001b[39m\u001b[39m{\u001b[39;00mextension\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m)\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=436'>437</a>\u001b[0m args \u001b[39m=\u001b[39m [image, extension, lang, config, nice, timeout, \u001b[39mTrue\u001b[39;00m]\n\u001b[0;32m--> <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=438'>439</a>\u001b[0m \u001b[39mreturn\u001b[39;00m run_and_get_output(\u001b[39m*\u001b[39;49margs)\n",
+      "File \u001b[0;32m~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py:286\u001b[0m, in \u001b[0;36mrun_and_get_output\u001b[0;34m(image, extension, lang, config, nice, timeout, return_bytes)\u001b[0m\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=274'>275</a>\u001b[0m \u001b[39mwith\u001b[39;00m save(image) \u001b[39mas\u001b[39;00m (temp_name, input_filename):\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=275'>276</a>\u001b[0m     kwargs \u001b[39m=\u001b[39m {\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=276'>277</a>\u001b[0m         \u001b[39m'\u001b[39m\u001b[39minput_filename\u001b[39m\u001b[39m'\u001b[39m: input_filename,\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=277'>278</a>\u001b[0m         \u001b[39m'\u001b[39m\u001b[39moutput_filename_base\u001b[39m\u001b[39m'\u001b[39m: temp_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=282'>283</a>\u001b[0m         \u001b[39m'\u001b[39m\u001b[39mtimeout\u001b[39m\u001b[39m'\u001b[39m: timeout,\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=283'>284</a>\u001b[0m     }\n\u001b[0;32m--> <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=285'>286</a>\u001b[0m     run_tesseract(\u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=286'>287</a>\u001b[0m     filename \u001b[39m=\u001b[39m kwargs[\u001b[39m'\u001b[39m\u001b[39moutput_filename_base\u001b[39m\u001b[39m'\u001b[39m] \u001b[39m+\u001b[39m extsep \u001b[39m+\u001b[39m extension\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=287'>288</a>\u001b[0m     \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39m(filename, \u001b[39m'\u001b[39m\u001b[39mrb\u001b[39m\u001b[39m'\u001b[39m) \u001b[39mas\u001b[39;00m output_file:\n",
+      "File \u001b[0;32m~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py:262\u001b[0m, in \u001b[0;36mrun_tesseract\u001b[0;34m(input_filename, output_filename_base, extension, lang, config, nice, timeout)\u001b[0m\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=259'>260</a>\u001b[0m \u001b[39mwith\u001b[39;00m timeout_manager(proc, timeout) \u001b[39mas\u001b[39;00m error_string:\n\u001b[1;32m    <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=260'>261</a>\u001b[0m     \u001b[39mif\u001b[39;00m proc\u001b[39m.\u001b[39mreturncode:\n\u001b[0;32m--> <a href='file:///~/anaconda3/envs/ultrasound/lib/python3.9/site-packages/pytesseract/pytesseract.py?line=261'>262</a>\u001b[0m         \u001b[39mraise\u001b[39;00m TesseractError(proc\u001b[39m.\u001b[39mreturncode, get_errors(error_string))\n",
+      "\u001b[0;31mTesseractError\u001b[0m: (1, 'Tesseract Open Source OCR Engine v4.1.1 with Leptonica Error in pixReadStream: Pdf reading is not supported Error in pixRead: pix not read Error during processing.')"
+     ]
+    }
+   ],
+   "source": [
+    "# Get a searchable PDF\n",
+    "pdf = pytesseract.image_to_pdf_or_hocr(surgical_file_example_path, extension='pdf')\n",
+    "with open('test.pdf', 'w+b') as f:\n",
+    "    f.write(pdf) # pdf type is bytes by default"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try with `pypdf2`. Same result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User: 0870530  1  2021-12-06 13:39:05\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# create file object variable\n",
+    "# opening method will be rb\n",
+    "pdffileobj=open(surgical_file_example_path,'rb')\n",
+    "#create reader variable that will read the pdffileobj\n",
+    "pdfreader=PyPDF2.PdfFileReader(pdffileobj)\n",
+    "#This will store the number of pages of this pdf file\n",
+    "x=pdfreader.numPages\n",
+    "#create a variable that will select the selected number of pages\n",
+    "pageobj=pdfreader.getPage(0)\n",
+    "#(x+1) because python indentation starts with 0.\n",
+    "#create text variable which will store all text datafrom pdf file\n",
+    "text=pageobj.extractText()\n",
+    "print(text) # doesn't do better than extract_text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try using the command line tool `pdftotext`. Same result. I think just a pdf to text method will be unable to get us the text because there appears to be 2 overlapping pdfs in the pdf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User: 0870530\n",
+      "\n",
+      "1\n",
+      "\n",
+      "2021-12-06 13:39:05\n",
+      "\n",
+      "\fUser: 0870530\n",
+      "\n",
+      "2\n",
+      "\n",
+      "2021-12-06 13:39:05\n",
+      "\n",
+      "\f"
+     ]
+    }
+   ],
+   "source": [
+    "!pdftotext '/home/c_spino/research/NLP_ultrasound_report/data/raw_data/pdf/surgical/51 O.pdf' -"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the pdf first to png with `pdf2image` and then png to text with `pytesseract`. This seems to work! Just slightly trickier because need to iterate through the converted images (from the pdf file)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images = convert_from_path(surgical_file_example_path)\n",
+    "for image in images:\n",
+    "    image.save('/home/c_spino/research/NLP_ultrasound_report/data/raw_data/png/surgical/51 O.png', 'PNG')\n",
+    "    img = Image.open('/home/c_spino/research/NLP_ultrasound_report/data/raw_data/png/surgical/51 O.png')\n",
+    "    print(img)\n",
+    "    print(pytesseract.image_to_string(image)) # tesseract is google backed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pathology\n",
+    "Try the same approach as surgical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=1700x2200 at 0x7F79C68EB1C0>\n",
+      "A\n",
+      "\n",
+      "Montreal Children’s Hospital\n",
+      "\n",
+      "Centre universitaire de santé McGill\n",
+      "\n",
+      "McGill University Health Centre 2300 rue Tupper\n",
+      "> : Montreal Quebec H3H 1P3\n",
+      "Département de Pathologie - Pathology Department HME/MCH (514) 412-4495 HGM/ MGH (514) 934-1934 poste 42819\n",
+      "\n",
+      "HRV/ RVH (514) 398-7174\n",
+      "\n",
+      " \n",
+      "\n",
+      "Autre nom:\n",
+      "See Dossier CUSM:\n",
+      "Medecin: Dr. Baird, Robert DDN:\n",
+      "\n",
+      "RAMQ / Carte santé:\n",
+      "CONFIDENTIEL / CONFIDENTIAL Téléphone:\n",
+      "Copie a:\n",
+      "\n",
+      " \n",
+      "\n",
+      "SURGICAL PATHOLOGY REPORT\n",
+      "\n",
+      "Collected: 2014-Mar-12 Case Number: =a\n",
+      "Received: 2014-Mar-13 12:28\n",
+      "\n",
+      "Reported: 2014-Mar-18 16:40\n",
+      "\n",
+      "CLINICAL INFORMATION\n",
+      "Appendicitis, no perforation?\n",
+      "? gangrene at appendix\n",
+      "\n",
+      "SPECIMEN\n",
+      "APPENDIX\n",
+      "\n",
+      "GROSS DESCRIPTION\n",
+      "\n",
+      "Specimen is received in formalin in one container, labelled with the patient's name and designated \"APPENDIX\". The\n",
+      "specimen consists of a vermiform appendix and mesoappendix, measuring 7.2 cm in length by 0.7 cm at the proximal\n",
+      "end and 1.3 cm in diameter at the distal end. The serosal surface is dull and congested. No gross perforation is\n",
+      "observed. Some fibrinous adhesions are seen near the distal end. On sectioning, a fecalith is observed at the mid\n",
+      "point of the appendix leading to a dilatation of the distal portion of the appendix. Otherwise the appendix contains\n",
+      "fecal material.\n",
+      "\n",
+      "Representative sections are submitted in cassette A1.\n",
+      "\n",
+      "POF/POF/CM\n",
+      "\n",
+      "DIAGNOSIS\n",
+      "\n",
+      "APPENDIX, APPENDECTOMY:\n",
+      "\n",
+      "- ACUTE APPENDICITIS AND PERIAPPENDICITIS.\n",
+      "CODE 1\n",
+      "\n",
+      "Electronically signed on 18-MAR-2014 04:40 pm\n",
+      "By Chantal Bernard, MD\n",
+      "\n",
+      " \n",
+      "\n",
+      "AVIS DE CONFIDENTIALITE - Si vous n’étes pas le destinataire de ce rapport, tout usage, divulgation, copie, ou distribution de ces informations\n",
+      "sont formellement interdits. $i vous avez recu ce rapport par erreur, veuillez $.V.P, nous en informer immédiatement au 514-934-1934 poste\n",
+      "31352, et nous le télécopier au 514-934-4457, S.V.P. le détruire par la suite.\n",
+      "\n",
+      "CONFIDENTIALITY - If you are not the intended recipient of this report, any use, disclosure, copying or distribution of this information is\n",
+      "prohibited. If you have received this report by error, please notify us immediately at 514-934-1934 ext-31352 and fax the report to 514-934-4457.\n",
+      "The report should then be destroyed.\n",
+      "\n",
+      "Print Date: 2014-03-19 00:31 Page 1 of 1\n",
+      "\n",
+      "Pathology Inpatient-v1 -Chart Report: 19601739\n",
+      "\n",
+      " \n",
+      "\n",
+      " \n",
+      "\n",
+      " \n",
+      "\n",
+      " \n",
+      "\n",
+      " \n",
+      "\n",
+      "User: 0870530 1 2021-12-06 13:44:06\n",
+      "\f\n"
+     ]
+    }
+   ],
+   "source": [
+    "images = convert_from_path(pathology_file_example_path)\n",
+    "for image in images:\n",
+    "    image.save('/home/c_spino/research/NLP_ultrasound_report/data/raw_data/png/pathology/51 P.png', 'PNG')\n",
+    "    img = Image.open('/home/c_spino/research/NLP_ultrasound_report/data/raw_data/png/pathology/51 P.png')\n",
+    "    print(img)\n",
+    "    print(pytesseract.image_to_string(image)) # tesseract is google backed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "6c6eee154cf23ccd188b1225944eddbdef9dcaacb443e60789f0b9c633324e67"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 ('ultrasound')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/script/pdf_txt.py
+++ b/script/pdf_txt.py
@@ -1,27 +1,47 @@
-#Goal of this python module is extract the text from pdf reports and create a txt version of it with the same name
-# pdf_txt.py
-# pdf
-#  ├─a.pdf
-#  ├─b.pdf
-#  └─c.pdf
-# txt
-    
-# all the pdf miner packages can simply be simpified to:
-# from pdfminer.high_level import extract_text
-#text = extract_text(file)
+import argparse
+import os
+from pathlib import Path
+from typing import Dict, Tuple
 
-def main():
-    #These are the packages needed to create this, the important package here is called pdfminer
-    from pathlib import Path
-    from pdfminer.pdfparser import PDFParser
-    from pdfminer.pdfdocument import PDFDocument
-    from pdfminer.pdfpage import PDFPage
-    from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
-    from pdfminer.pdfdevice import PDFDevice
-    from pdfminer.layout import LAParams, LTTextBox, LTTextLine
-    from pdfminer.converter import PDFPageAggregator
+from pdfminer.converter import PDFPageAggregator
+from pdfminer.layout import LAParams, LTTextBox, LTTextLine
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
+from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfparser import PDFParser
 
-    for path in Path("pdf").glob("*.pdf"):
+
+def read_args() -> Tuple[Path, Path]:
+    parser = argparse.ArgumentParser(
+        description="Convert pdf files in a directory to text files with the same name."
+    )
+    parser.add_argument(
+        "-p",
+        "--pdf_folder_input_path",
+        help="The folder path that contains the pdf files.",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--text_folder_output_path",
+        help="The folder path that will be sued to write out the converted text files.",
+        required=True,
+    )
+    args = parser.parse_args()
+    pdf_folder_input_path = Path(args.pdf_folder_input_path)
+    text_folder_output_path = Path(args.text_folder_output_path)
+    assert (
+        pdf_folder_input_path.exists() and pdf_folder_input_path.is_dir()
+    ), "The input pdf folder does not exist or is not a folder directory."
+    if not text_folder_output_path.exists():
+        print("The output text folder does not exists, creating it.")
+        os.makedirs(text_folder_output_path)
+    return pdf_folder_input_path, text_folder_output_path
+
+
+def read_pdf_text(pdf_file_path: Path) -> Dict[str, str]:
+    pdf_text_dict = {}
+    for path in Path(pdf_file_path).glob("*.pdf"):
         with path.open("rb") as file:
             parser = PDFParser(file)
             document = PDFDocument(parser, "")
@@ -41,11 +61,44 @@ def main():
                 for obj in device.get_result():
                     if isinstance(obj, LTTextBox) or isinstance(obj, LTTextLine):
                         text += obj.get_text()
-        with open("txt/{}.txt".format(path.stem), "w") as file:
+            pdf_text_dict[path.stem] = text
+    return pdf_text_dict
+
+
+def write_text(pdf_text_dict: Dict[str, str], text_folder_output_path: Path) -> None:
+    for path_stem, text in pdf_text_dict.items():
+        output_file_path = os.path.join(text_folder_output_path, f"{path_stem}.txt")
+        with open(output_file_path, "w") as file:
             file.write(text)
-    return 0
+
+
+def main():
+    """
+    Goal of this python script is to extract the text from pdf reports 
+    and create a txt version of it with the same name.
+
+    Example:
+    python pdf_txt.py --pdf_folder_input_path=pdf --text_folder_output_path=txt
+    Input:
+    pdf
+     ├─a.pdf
+     ├─b.pdf
+     └─c.pdf
+    Result:
+    txt
+     ├─a.txt
+     ├─b.txt
+     └─c.txt
+    """
+    # Read command line arguments
+    pdf_folder_input_path, text_folder_output_path = read_args()
+    # Read pdf files and convert to text files
+    print("Reading pdf files...")
+    pdf_text_dict = read_pdf_text(pdf_folder_input_path)
+    # Write out each text file using the same pdf file name
+    print("Writing text files...")
+    write_text(pdf_text_dict, text_folder_output_path)
 
 
 if __name__ == "__main__":
-    import sys
-    sys.exit(main())
+    main()


### PR DESCRIPTION
## What does this PR do?
Refactor of the `pdf_text.py` script so that it can support the surgical and pathology reports. The result on ultrasound report should remain the same. To allow the surgical and pathology conversion to text, an extra step has been added to firstly convert the pdf to images (png).

You can call this script by running:
```
python pdf_text.py -r {report_type=ultrasound,surgical,pathology} -p {pdf input folder path} -t {text output folder path} -i {if report_type is surgical or pathology, specify the image output folder path which will store the intermediate version of the pdf as images}
```

## Notion ticket number?
https://www.notion.so/Write-a-script-for-text-conversion-surgical-and-pathology-f4d26055e7a64e5b9b5d5f5d0fd2940c

## Is this a breaking change?
Yes, previous use of `pdf_text.py` will no longer work. You will now need to use the command line to specify the path of the directory that contains pdf files as well as the output folder.
